### PR TITLE
Allow specific placement of debugger UI

### DIFF
--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -4,10 +4,10 @@ import Debugger from './components/debugger'
 
 export default function (app, options) {
   var container = document.createElement('div')
-
   container.className = "debugger-wrapper"
 
-  document.body.appendChild(container)
+  var parentContainer = document.getElementById('microcosm-debugger') || document.body
+  parentContainer.appendChild(container)
 
   function checkout (action) {
     app.checkout(action)


### PR DESCRIPTION
If an element with id equal to `microcosm-debugger` exists, append the debugger to that element instead of `document.body`.
